### PR TITLE
Update tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,7 @@
 minversion = 1.6
 envlist = linters,jjb,jenkins-project,zuul
 skipsdist = True
+skip_missing_interpreters = True
 
 [testenv]
 deps = -r{toxinidir}/test-requirements.txt


### PR DESCRIPTION
Add `skip_missing_interpreters = True` to avoid failing when missing interpreters like python 2.6 and 3.4